### PR TITLE
Simplify DAG sys.path configuration

### DIFF
--- a/dags/movie_etl_dag.py
+++ b/dags/movie_etl_dag.py
@@ -1,8 +1,7 @@
 import os
 import sys
 # get path of python files to run
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../ml')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from src.extract_movies import extract_movies
 from src.extract_genres import extract_genres


### PR DESCRIPTION
## Summary
- simplify `sys.path` setup in `movie_etl_dag` so repository root is inserted once

## Testing
- `python -m py_compile dags/movie_etl_dag.py`
- `python dags/movie_etl_dag.py` *(fails: ModuleNotFoundError: pandas)*
- `airflow version` *(fails: TypeError: 'module' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689e52fd76c48330950710a4f805b47d