### PR TITLE
Fix logger import paths and update dependencies

### DIFF
--- a/ml/preprocess_text.py
+++ b/ml/preprocess_text.py
@@ -2,7 +2,7 @@ import re
 import logging
 import os
 import pandas as pd
-from logger import *
+from src.logger import *
 from db.db_connector import get_engine
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4
 python-dotenv
 scikit-learn
 iterative-stratification
+pandas

--- a/src/extract_budget_revenue.py
+++ b/src/extract_budget_revenue.py
@@ -1,6 +1,6 @@
 import requests
 import pandas as pd
-from logger import log_extract_start, log_extract_end, log_error, log_info
+from src.logger import log_extract_start, log_extract_end, log_error, log_info
 from db.db_connector import get_engine
 from airflow.models import Variable
 from requests.adapters import HTTPAdapter, Retry

--- a/src/extract_genres.py
+++ b/src/extract_genres.py
@@ -1,7 +1,7 @@
 import os
 import requests
 import pandas as pd
-from logger import log_extract_start, log_extract_end, log_error, log_info
+from src.logger import log_extract_start, log_extract_end, log_error, log_info
 from db.db_connector import get_engine
 from airflow.models import Variable
 

--- a/src/extract_movies.py
+++ b/src/extract_movies.py
@@ -1,7 +1,7 @@
 import os
 import requests
 import pandas as pd
-from logger import log_extract_start, log_extract_end, log_error, log_info
+from src.logger import log_extract_start, log_extract_end, log_error, log_info
 from airflow.models import Variable
 from db.db_connector import get_engine
 from datetime import datetime, timezone

--- a/src/transform_gold_layer.py
+++ b/src/transform_gold_layer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import logging
 import os
-from logger import *
+from src.logger import *
 from airflow.models import Variable
 from db.db_connector import get_engine
 

--- a/src/transform_silver_layer.py
+++ b/src/transform_silver_layer.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import os
 import requests
-import ast  # helps parse stringified listsfrom airflow.models import Variable
+import ast  # helps parse stringified lists
 from db.db_connector import get_engine
-from logger import *
+from src.logger import *
 from airflow.models import Variable
 
 TMDB_API_KEY = Variable.get("MY_API_KEY")


### PR DESCRIPTION
## Summary
- use package-qualified imports for logger module across extraction, transformation and ML scripts
- document pandas as a dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- Attempted to install pandas for import tests, but pip could not access the package index (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689e579aa0648330a24397fea0f7d8f6