### PR TITLE
Mount db package for Airflow DAGs

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database helpers package."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./src:/opt/airflow/src
       - ./ml:/opt/airflow/ml
       - ./sql:/opt/airflow/sql
+      - ./db:/opt/airflow/db
     command: webserver
 
   airflow-scheduler:
@@ -47,3 +48,4 @@ services:
       - ./src:/opt/airflow/src
       - ./ml:/opt/airflow/ml
       - ./sql:/opt/airflow/sql
+      - ./db:/opt/airflow/db


### PR DESCRIPTION
## Summary
- mount `db` package in Airflow webserver and scheduler containers
- add package initializer for `db`

## Testing
- `python -m pytest`
- `python - <<'PY'
from db.db_connector import get_engine
print('engine function loaded', callable(get_engine))
PY` *(fails: TypeError: 'module' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_689f62e35e00833090c498172ff2a7fd