### PR TITLE
Save ML artifacts to S3 and share via XCom

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn
 iterative-stratification
 pandas
 joblib>=1.3.2
+boto3


### PR DESCRIPTION
## Summary
- upload genre model training artifacts to S3 with timestamped version folders
- push S3 artifact URIs to XCom and load them in prediction step
- add boto3 dependency

## Testing
- `python -m py_compile ml/train_genre_multilabel.py ml/predict_genre.py`


------
https://chatgpt.com/codex/tasks/task_e_689f736d7c848330b629d95ce66f23a6